### PR TITLE
encryptAndDecryptNonPasswordFields

### DIFF
--- a/Background Scripts/encryptAndDecryptNonPasswordFields.js
+++ b/Background Scripts/encryptAndDecryptNonPasswordFields.js
@@ -1,0 +1,21 @@
+//To Encrypt password field
+var grIncident = new GlideRecord('incident');
+if (grIncident.get('dc1c4143476202101b589d2f316d4390')) {
+ grIncident.setDisplayValue('u_pass', 'demo@123');
+ grIncident.update();
+}
+//NOTE: You can't use the setValue() API for the Password2 field
+
+//To print cipher text
+var grIncident = new GlideRecord('incident');
+if (grIncident.get('dc1c4143476202101b589d2f316d4390')) {
+ gs.info('Encrypted cipher test of password ' + grIncident.getValue('u_pass'));
+}
+
+//To decrypt password field
+var grIncident = new GlideRecord('incident');
+if (grIncident.get('dc1c4143476202101b589d2f316d4390')) {
+ var result = grIncident.u_pass.getDecryptedValue();
+ gs.info("Decrypted password- " +result);
+}
+//NOTE: The getDecryptedValue() API isn't scoped. It's available globally.

--- a/Background Scripts/readme.md
+++ b/Background Scripts/readme.md
@@ -1,11 +1,10 @@
-Generally when you want to encrypt or decrypt any Non-password fields earlier we have Glide Encrypter API methods for encryption and decryption. 
-The GlideEncrypter API uses 3DES encryption standard with NIST 800-131 A Rev2 has recommended against using to encrypt data after 2023. 
-ServiceNow offers alternative cryptographic (Key Management Framwork) solutions to the GlideEncrypter API. 
+Dear ServiceNow Community,
 
-Note: ServiceNow recommending to deprecate GlideEncrypter API with in the instances as soon as possible. The actual dead line is September 2025.
 
-These are the sample scripts I ran in my PDI: For Non-password fields. I used AES 256 algorithm for Symmetric Data Encryption/Decryption.
+The GlideEncrypter API uses 3DES encryption standard with NIST 800-131 A Rev2 has recommended against using to encrypt data after 2023. ServiceNow offers alternative cryptographic solutions to the GlideEncrypter API. 
 
-To test the scripts you need to create Cryptographic module and generate the key. 
+Glide Element API to encrypt/decrypt password2 values through GlideRecord.
 
-"global.vamsi_glideencrypter" is my cryptographic module name.
+Below are the sample scripts I ran in my PDI: For Password fields. 
+
+Note: 'u_pass' is Password (2 Way Encrypted) field.


### PR DESCRIPTION
Dear ServiceNow Community,


The GlideEncrypter API uses 3DES encryption standard with NIST 800-131 A Rev2 has recommended against using to encrypt data after 2023. ServiceNow offers alternative cryptographic solutions to the GlideEncrypter API. 

Glide Element API to encrypt/decrypt password2 values through GlideRecord.

Below are the sample scripts I ran in my PDI: For Password fields. 

Note: 'u_pass' is Password (2 Way Encrypted) field.